### PR TITLE
Consolidate field map layers into FAB dropdown

### DIFF
--- a/src/components/field/LayerSelectionFab.tsx
+++ b/src/components/field/LayerSelectionFab.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { Fingerprint, Rewind, Users, Maximize2, Minimize2 } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import { useTimewarpDrawer } from '@/contexts/TimewarpDrawerContext';
+import { useFriendDrawer } from '@/contexts/FriendDrawerContext';
+import { useFullscreenMap } from '@/store/useFullscreenMap';
+
+export const LayerSelectionFab = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  
+  // Hook into existing functionality
+  const { open: timewarpOpen, toggle: toggleTimewarp } = useTimewarpDrawer();
+  const { open: friendOpen, toggle: toggleFriend } = useFriendDrawer();
+  const { mode: fullscreenMode, toggleFull } = useFullscreenMap();
+  
+  const isFull = fullscreenMode === 'full';
+
+  const handleTimewarpToggle = () => {
+    toggleTimewarp();
+    setIsOpen(false);
+  };
+
+  const handleFriendToggle = () => {
+    toggleFriend();
+    setIsOpen(false);
+  };
+
+  const handleFullscreenToggle = () => {
+    toggleFull();
+    setIsOpen(false);
+  };
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label="Layer selection menu"
+          aria-controls="layer-selection-menu"
+          aria-expanded={isOpen}
+          className="
+            fixed top-20 right-4 z-[65] h-11 w-11
+            rounded-full bg-background/90 backdrop-blur
+            flex items-center justify-center shadow-lg
+            border border-border hover:bg-muted/50 transition-colors
+            hover:scale-105 active:scale-95
+          "
+        >
+          <Fingerprint className="h-5 w-5" />
+        </button>
+      </DropdownMenuTrigger>
+      
+      <DropdownMenuContent 
+        align="end" 
+        className="w-48 bg-background/95 backdrop-blur border-border"
+        sideOffset={8}
+      >
+        <DropdownMenuItem 
+          onClick={handleTimewarpToggle}
+          className="flex items-center gap-3 cursor-pointer hover:bg-muted/50 focus:bg-muted/50"
+        >
+          <Rewind className="h-4 w-4" />
+          <span>Timewarp Layer</span>
+          {timewarpOpen && (
+            <div className="ml-auto w-2 h-2 rounded-full bg-primary animate-pulse" />
+          )}
+        </DropdownMenuItem>
+        
+        <DropdownMenuItem 
+          onClick={handleFriendToggle}
+          className="flex items-center gap-3 cursor-pointer hover:bg-muted/50 focus:bg-muted/50"
+        >
+          <Users className="h-4 w-4" />
+          <span>Friend Layer</span>
+          {friendOpen && (
+            <div className="ml-auto w-2 h-2 rounded-full bg-primary animate-pulse" />
+          )}
+        </DropdownMenuItem>
+        
+        <DropdownMenuSeparator className="bg-border" />
+        
+        <DropdownMenuItem 
+          onClick={handleFullscreenToggle}
+          className="flex items-center gap-3 cursor-pointer hover:bg-muted/50 focus:bg-muted/50"
+        >
+          {isFull ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          <span>{isFull ? 'Exit Fullscreen' : 'Enter Fullscreen'}</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/screens/field/FieldLayout.tsx
+++ b/src/components/screens/field/FieldLayout.tsx
@@ -20,11 +20,10 @@ import type { LocationError } from "@/types/overrides";
 import { useGeo } from "@/hooks/useGeo";
 
 import { FriendDrawerProvider } from "@/contexts/FriendDrawerContext";
-import { FriendFab } from "@/components/field/FriendFab";
 import { FriendDrawer } from "@/components/field/FriendDrawer";
 import { TimewarpDrawerProvider } from "@/contexts/TimewarpDrawerContext";
-import { TimewarpFab } from "@/components/field/TimewarpFab";
 import { TimewarpDrawer } from "@/components/field/TimewarpDrawer";
+import { LayerSelectionFab } from "@/components/field/LayerSelectionFab";
 import { ProximityNotifications } from "@/components/location/ProximityNotifications";
 import { useEnhancedFriendDistances } from "@/hooks/useEnhancedFriendDistances";
 import { useDebugLocationToast } from "@/components/debug/useDebugLocationToast";
@@ -221,11 +220,8 @@ export const FieldLayout = () => {
             <TimewarpDrawer />
           </BottomHud>
 
-          {/* Friend FAB - z-65 */}
-          <FriendFab />
-
-          {/* Timewarp FAB - z-65 */}
-          <TimewarpFab />
+          {/* Layer Selection FAB - consolidated controls - z-65 */}
+          <LayerSelectionFab />
 
           {/* Proximity Notifications - z-50 */}
           <ProximityNotifications />

--- a/src/components/screens/field/FieldSystemLayer.tsx
+++ b/src/components/screens/field/FieldSystemLayer.tsx
@@ -1,5 +1,4 @@
 
-import { FullscreenFab } from "@/components/map/FullscreenFab";
 import { Z, zIndex } from "@/constants/z";
 import { useFieldUI } from "@/components/field/contexts/FieldUIContext";
 import { useAutoCheckIn } from "@/hooks/useAutoCheckIn";
@@ -17,13 +16,6 @@ export const FieldSystemLayer = ({ data }: FieldSystemLayerProps) => {
 
   return (
     <>
-      {/* ——— Fullscreen-map FAB —————————————— */}
-      <div 
-        className="fixed bottom-24 right-4 pointer-events-auto"
-        {...zIndex('system')}
-      >
-        <FullscreenFab />
-      </div>
 
       {/* ——— Auto Check-in Status (Development Only) —————————————— */}
       {process.env.NODE_ENV === 'development' && (


### PR DESCRIPTION
Consolidate map layer controls into a single dropdown FAB to reduce UI clutter on the field screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-f71382bf-6c53-4a50-b9e2-c40e0eff398f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f71382bf-6c53-4a50-b9e2-c40e0eff398f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

