### PR TITLE
Implement live plan presence and check-in features

### DIFF
--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -1,5 +1,13 @@
 import { useUnreadBadgeRealtime } from "@/hooks/useUnreadBadgeRealtime";
 import { useCurrentProfileId } from "@/hooks/useCurrentUser";
+import { usePresenceTracker } from '@/hooks/usePresenceTracker';
+
+function PresenceHeartbeatMount() {
+  // Sends periodic heartbeats to user_online_status.
+  // No props; safe to mount once at app root.
+  usePresenceTracker();
+  return null;
+}
 
 export const AppProviders = ({ children }: { children: React.ReactNode }) => {
   const currentProfileId = useCurrentProfileId();
@@ -8,5 +16,11 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
   // Hook already guards against undefined profileId internally
   useUnreadBadgeRealtime(currentProfileId);
 
-  return <>{children}</>;
+  return (
+    <>
+      {/* Global online presence heartbeat */}
+      <PresenceHeartbeatMount />
+      {children}
+    </>
+  );
 };

--- a/src/components/plans/PlanDetailsView.tsx
+++ b/src/components/plans/PlanDetailsView.tsx
@@ -10,6 +10,7 @@ import { Separator } from '@/components/ui/separator';
 import { ChevronLeft, Calendar, Clock, Users, MapPin } from 'lucide-react';
 import { PlanEditModal } from './PlanEditModal';
 import { PlanTimelinePreview } from './PlanTimelinePreview';
+import { LivePlanTimeline } from '@/components/planning/LivePlanTimeline';
 import { PlanSummaryStats } from './PlanSummaryStats';
 import { PlanParticipantsList } from './PlanParticipantsList';
 import { PlanQuickActions } from './PlanQuickActions';
@@ -319,10 +320,14 @@ export const PlanDetailsView: React.FC = () => {
             <Clock className="w-4 h-4" />
             Timeline
           </h3>
-          <PlanTimelinePreview 
-            stops={stops} 
-            isLoading={stopsLoading}
-          />
+          {plan.status === 'executing' ? (
+            <LivePlanTimeline planId={planId!} className="mt-2" />
+          ) : (
+            <PlanTimelinePreview 
+              stops={stops} 
+              isLoading={stopsLoading}
+            />
+          )}
         </div>
 
         {/* Participants */}

--- a/src/components/ui/PresenceBadge.tsx
+++ b/src/components/ui/PresenceBadge.tsx
@@ -9,10 +9,14 @@ type Props =
   | { kind: 'lastSeen'; ts: string };
 
 export function PresenceBadge(p: Props) {
-  if (p.kind === 'arrived') return <Badge variant="default" className="bg-green-500 text-white border-green-500">Arrived</Badge>;
-  if (p.kind === 'enroute') return <Badge>En-route</Badge>;
+  if (p.kind === 'arrived') {
+    return <Badge variant="default" className="bg-green-500 text-white border-green-500">Arrived</Badge>;
+  }
+  if (p.kind === 'enroute') {
+    return <Badge>En-route</Badge>;
+  }
 
-  /* last-seen */
+  // last-seen
   return (
     <span className="text-xs text-muted-foreground">
       {dayjs(p.ts).fromNow(true)}

--- a/src/hooks/usePlanCheckinToast.ts
+++ b/src/hooks/usePlanCheckinToast.ts
@@ -2,21 +2,35 @@ import { useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
-export function usePlanCheckinToast(planId?:string){
+export function usePlanCheckinToast(planId?: string) {
   const { toast } = useToast();
 
-  useEffect(()=>{
-    if(!planId) return;
-    const ch = supabase.channel(`checkin_${planId}`)
-      .on('broadcast',{event:'plan_checkin_ready'}, ({payload})=>{
-        if(payload.plan_id === planId){
+  useEffect(() => {
+    if (!planId) return;
+
+    const channel = supabase.channel(`plan_check_ins_${planId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'plan_check_ins',
+          filter: `plan_id=eq.${planId}`,
+        },
+        (payload: any) => {
+          const row = payload.new || {};
           toast({
-            title:'Checked-in ✅',
-            description: payload.title ? `Auto-checked in at ${payload.title}` : 'You were automatically checked-in to this stop'
+            title: 'Checked-in ✅',
+            description: row.title
+              ? `Auto-checked in at ${row.title}`
+              : 'You were automatically checked-in to this stop',
           });
         }
-      })
+      )
       .subscribe();
-    return ()=>{ supabase.removeChannel(ch); };
-  },[planId, toast]);
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [planId, toast]);
 }

--- a/src/hooks/useVenueStaysChannel.ts
+++ b/src/hooks/useVenueStaysChannel.ts
@@ -2,43 +2,48 @@ import { useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 
 export type StayEvent =
-  | { type:'stay_insert'; id:number; profile_id:string; venue_id:string; arrived_at:string; plan_id?:string|null; stop_id?:string|null }
-  | { type:'stay_depart'; id:number; profile_id:string; venue_id:string; departed_at:string; plan_id?:string|null; stop_id?:string|null };
+  | { type: 'stay_insert'; id: number; profile_id: string | null; venue_id: string; arrived_at: string; plan_id?: string | null; stop_id?: string | null }
+  | { type: 'stay_depart'; id: number; profile_id: string | null; venue_id: string; departed_at: string; plan_id?: string | null; stop_id?: string | null };
 
-export function useVenueStaysChannel(
-  onEvent:(e:StayEvent)=>void
-){
-  useEffect(()=>{
-    const ch = supabase.channel('venue_stays_frontend')
-      .on('postgres_changes', { 
-        event: '*', 
-        schema: 'public',
-        table: 'venue_stays'
-      }, (payload) => {
-        if (payload.eventType === 'INSERT') {
-          onEvent({
-            type: 'stay_insert',
-            id: payload.new.id,
-            profile_id: payload.new.profile_id,
-            venue_id: payload.new.venue_id,
-            arrived_at: payload.new.arrived_at,
-            plan_id: payload.new.plan_id,
-            stop_id: payload.new.stop_id
-          });
-        } else if (payload.eventType === 'UPDATE' && payload.new.departed_at) {
-          onEvent({
-            type: 'stay_depart',
-            id: payload.new.id,
-            profile_id: payload.new.profile_id,
-            venue_id: payload.new.venue_id,
-            departed_at: payload.new.departed_at,
-            plan_id: payload.new.plan_id,
-            stop_id: payload.new.stop_id
-          });
+export function useVenueStaysChannel(onEvent: (e: StayEvent) => void) {
+  useEffect(() => {
+    const ch = supabase
+      .channel('venue_stays_frontend')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'venue_stays' },
+        (payload: any) => {
+          if (payload.eventType === 'INSERT') {
+            onEvent({
+              type: 'stay_insert',
+              id: payload.new.id,
+              profile_id: payload.new.profile_id,
+              venue_id: payload.new.venue_id,
+              arrived_at: payload.new.arrived_at,
+              plan_id: (payload.new as any).plan_id ?? null,
+              stop_id: (payload.new as any).stop_id ?? null,
+            });
+          } else if (
+            payload.eventType === 'UPDATE' &&
+            payload.new.departed_at &&
+            !payload.old?.departed_at
+          ) {
+            onEvent({
+              type: 'stay_depart',
+              id: payload.new.id,
+              profile_id: payload.new.profile_id,
+              venue_id: payload.new.venue_id,
+              departed_at: payload.new.departed_at,
+              plan_id: (payload.new as any).plan_id ?? null,
+              stop_id: (payload.new as any).stop_id ?? null,
+            });
+          }
         }
-      })
+      )
       .subscribe();
 
-    return ()=>{ supabase.removeChannel(ch); };
-  },[onEvent]);
+    return () => {
+      supabase.removeChannel(ch);
+    };
+  }, [onEvent]);
 }


### PR DESCRIPTION
Enables Phase 0 real-time plan features and global presence by mounting live components and standardizing real-time subscriptions.

The auto check-in toast previously relied on a 'broadcast' event which was not triggered by the backend's `pg_notify`. This PR updates the frontend to listen for `postgres_changes` on `plan_check_ins` directly, ensuring reliable notifications consistent with the app's real-time architecture.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe62c7b4-c289-4fef-8b5a-b6670b949167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe62c7b4-c289-4fef-8b5a-b6670b949167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

