### PR TITLE
Debug useSyncExternalStore import error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,10 @@ export default defineConfig(({ mode, command }) => {
         'react-dom', 
         'react/jsx-runtime', 
         'react-native-web',
+        // Ensure CJS shim is wrapped to ESM so named export exists
+        'use-sync-external-store',
+        'use-sync-external-store/shim',
+        'use-sync-external-store/shim/with-selector',
         // Let Vite auto-discover and prebundle Supabase packages naturally
         '@supabase/supabase-js',
         '@supabase/postgrest-js',


### PR DESCRIPTION
Explicitly include `use-sync-external-store` and its shims in Vite's `optimizeDeps.include` to resolve a `useSyncExternalStore` named export error.

The error occurred because Vite's dependency optimization was disabled, causing it to serve the CommonJS shim of `use-sync-external-store` directly. This prevented the `useSyncExternalStore` named export from being available, leading to a `SyntaxError`. Explicitly including these paths forces Vite to pre-bundle them as ESM.

---
<a href="https://cursor.com/background-agent?bcId=bc-e383894d-01ef-4903-826c-23f8b6841526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e383894d-01ef-4903-826c-23f8b6841526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

