### PR TITLE
Fix dayjs import error for lovable preview

### DIFF
--- a/src/components/ui/PresenceBadge.tsx
+++ b/src/components/ui/PresenceBadge.tsx
@@ -1,7 +1,5 @@
 import dayjs from '@/lib/dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
 import { Badge } from '@/components/ui/badge';
-dayjs.extend(relativeTime);
 
 type Props =
   | { kind: 'arrived' }

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import relativeTime from 'dayjs/plugin/relativeTime';
+import * as utc from 'dayjs/plugin/utc';
+import * as relativeTime from 'dayjs/plugin/relativeTime';
 
-dayjs.extend(utc);
-dayjs.extend(relativeTime);
+dayjs.extend((utc as any).default || (utc as any));
+dayjs.extend((relativeTime as any).default || (relativeTime as any));
 
 export default dayjs; 

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,7 +1,4 @@
 import dayjs from '@/lib/dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-
-dayjs.extend(relativeTime);
 
 export const human = (ts: string) => dayjs(ts).fromNow();
 


### PR DESCRIPTION
Fix Day.js plugin import error by centralizing plugin extensions with robust ESM/CJS interop in `src/lib/dayjs.ts`.

The "does not provide an export named 'default'" error occurred because Vite (an ESM-first bundler) encountered Day.js plugins that were not exporting a default in a way it expected. The fix involves importing plugins as `* as` and then conditionally extending `(plugin as any).default || plugin` to correctly handle both ESM and CommonJS module structures, centralizing this logic in `src/lib/dayjs.ts` and removing redundant plugin extensions from other files.

---
<a href="https://cursor.com/background-agent?bcId=bc-7dc07a0d-76fa-4c89-87f7-3d89a7b85484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7dc07a0d-76fa-4c89-87f7-3d89a7b85484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

